### PR TITLE
Set target for profiler to a new tab in browser

### DIFF
--- a/Resources/views/Profiler/toolbar_item.html.twig
+++ b/Resources/views/Profiler/toolbar_item.html.twig
@@ -1,5 +1,5 @@
 <div class="sf-toolbar-block sf-toolbar-block-{{ name }} sf-toolbar-status-{{ status|default('normal') }}">
-    {% if link %}<a href="{{ path('_profiler', { token: token, panel: name }) }}">{% endif %}
+    {% if link %}<a href="{{ path('_profiler', { token: token, panel: name }) }}" target="_blank">{% endif %}
         <div class="sf-toolbar-icon">{{ icon|default('') }}</div>
     {% if link %}</a>{% endif %}
         <div class="sf-toolbar-info">{{ text|default('') }}</div>


### PR DESCRIPTION
This also has an added benefit of allowing angular routes to operate normally. Setting target to `_self` or `_blank` causes angular $location service to not intercept location change.
